### PR TITLE
docs: code review report + Paycheck Estimator spec

### DIFF
--- a/docs/CODE-REVIEW.md
+++ b/docs/CODE-REVIEW.md
@@ -1,0 +1,274 @@
+# FREEDomCalculator — Code & Architecture Review
+
+**Date:** 2026-07-02
+**Scope:** Full application review — security, performance, stability/correctness. Read-only; no code was changed.
+**Verified against:** a fresh `npm run build` (passes), `npm audit` (0 vulnerabilities), `npm outdated`, and direct source inspection. All file/line references are from the current `main` branch.
+
+---
+
+## 1. Executive Summary
+
+**Overall health: good.** This is a small, client-only, dependency-light React app with no secrets, no server, no user-generated HTML, and zero known-vulnerable packages. The shared-utility conventions (`NumericOrEmpty`, `formatters.ts` Intl singletons, validate-first flow) are applied consistently. The most significant problems are *product/stability* contradictions (a PWA that un-installs itself), *type-safety erosion* around `useLocalStorage` (`data!` assertions on data that can be corrupted), and a handful of financial-math edge cases that produce `NaN`/`Infinity` or educationally misleading numbers.
+
+### Top 5 risks
+
+1. **The PWA is registered and then immediately destroyed on every load** — `main.tsx` purges all service workers and caches while `vite.config.ts` installs one. Offline support (advertised prominently in `README.md`) does not work, and every fresh session pays an extra full page reload. (Finding ST-1)
+2. **`localStorage` data is trusted blindly** — `useLocalStorage` returns whatever `JSON.parse` produces, and calculators dereference it with `data!.field` non-null assertions. A stale or hand-edited stored shape can put strings/null where numbers are expected and crash or silently miscompute. (Findings SEC-1, ST-2)
+3. **Compound Interest calculator mixes compounding models** — deposits are always compounded monthly even when "Annually" is selected, so the "Compounding Frequency" control misleads students for its primary use case. (Finding ST-4)
+4. **Single 890 kB JS chunk (262 kB gzip)** — everything (React, recharts, all 9 calculators) ships in one file. The static-import decision is documented and should be preserved, but a `manualChunks` vendor split would restore caching granularity without touching import style. (Finding PERF-1)
+5. **Silent 600-month truncation and `NaN`/`Infinity` edge cases** in Credit Card, Inflation, and TVM calculators can show wrong numbers with no error. (Findings ST-5, ST-6, ST-7)
+
+### What's already healthy (no action needed)
+
+- `npm audit`: **0 vulnerabilities** (prod and dev). Dependencies are within one minor version of latest except deliberate majors (Vite 6 vs 8, TS 5.9 vs 6 — both fine).
+- No secrets, tokens, or API keys anywhere in `src/` (grep for `api[_-]?key|secret|token|password`: no hits).
+- No user-controlled HTML: the only `dangerouslySetInnerHTML` is in the unused shadcn `chart.tsx` (see SEC-3).
+- `Intl` formatters are module-level singletons ([formatters.ts:3-12](../src/lib/formatters.ts)) — the expensive-construction trap is already avoided and documented.
+- Inputs are labeled (`Label htmlFor` pairs with input `id`s), scroll arrows have `aria-label`s, error messages render in `Alert` components.
+- Error boundary wraps the whole app ([main.tsx:49-55](../src/main.tsx)).
+
+---
+
+## 2. Findings Table
+
+| ID | Area | Severity | File:line | Issue | Why it matters |
+|------|-------------|----------|-----------|-------|----------------|
+| ST-1 | Stability/PWA | **High** | [src/main.tsx:21-47](../src/main.tsx) vs [vite.config.ts:12-71](../vite.config.ts) | `purgeServiceWorkers()` unregisters the SW and deletes all caches on every load, while VitePWA (`registerType: 'autoUpdate'`) re-registers it via injected `registerSW.js` | Offline support is dead despite README advertising it; every fresh browser session performs register → purge → forced reload (extra full page load); wasted 1.1 MB precache work on every visit |
+| SEC-1 | Security | **Medium** | [src/hooks/useLocalStorage.ts:10-11](../src/hooks/useLocalStorage.ts) | `JSON.parse(item)` result is returned as `T` with no shape validation; schema drift between releases is undetected | Corrupt/stale/hand-edited values flow into calculators typed as numbers; combined with ST-2 this can crash the tab or silently compute garbage |
+| ST-2 | Stability/TS | **Medium** | [AutoLoanCalculator.tsx:53-75](../src/components/AutoLoanCalculator.tsx), [CreditCardCalculator.tsx:114-342](../src/components/CreditCardCalculator.tsx), [MortgageCalculator.tsx:70-96](../src/components/MortgageCalculator.tsx), [TimeValueOfMoneyCalculator.tsx:196-466](../src/components/TimeValueOfMoneyCalculator.tsx) | ~35 `data!.` non-null assertions on state that comes from `useLocalStorage`/`useState` | The assertions paper over exactly the case SEC-1 creates; strict TS is being defeated where it matters most |
+| ST-4 | Correctness | **Medium** | [CompoundInterestCalculator.tsx:85-108](../src/components/CompoundInterestCalculator.tsx) | Principal growth honors the selected compounding frequency (`n`), but monthly deposits always compound at `r/12` regardless of selection; results/chart never mix models consistently | The calculator's own headline control ("Compounding Frequency") doesn't do what students are told it does when deposits are present — an educational-accuracy bug in an educational app |
+| ST-5 | Correctness | **Medium** | [CreditCardCalculator.tsx:126-198](../src/components/CreditCardCalculator.tsx) | Loop caps at 600 months but falls through to `setResults` with no warning; also `minimumPayment` is treated as a **dollar floor** (`Math.max(minimumPayment, interest + 1% of balance)`) while validation messages call it a "percentage" ([line 215-217](../src/components/CreditCardCalculator.tsx)) | A user who genuinely never pays off sees "600 months" presented as a real payoff time; the dollar-vs-percentage confusion misleads both users and future maintainers |
+| ST-6 | Correctness | **Medium** | [InflationCalculator.tsx:60-88](../src/components/InflationCalculator.tsx) | `isValidNumber` accepts 0 and negatives: `currentAmount = 0` → `percentageLost = NaN` rendered; `inflationRate = -100` → division by `Math.pow(0, years)` → `Infinity`; negative `years` silently yields an empty chart | NaN/Infinity render directly into the results cards; `validateCalculatorInputs` (which rejects `<= 0`) exists in the shared lib but this calculator rolls its own check with `isValidNumber` only |
+| ST-7 | Correctness | **Medium** | [TimeValueOfMoneyCalculator.tsx:117-176](../src/components/TimeValueOfMoneyCalculator.tsx) | Newton-Raphson `solveForRate`/`solveForPeriods` return the last iterate even when convergence failed (`df` near zero → `break` → return garbage); no residual check on exit | For pathological inputs (sign-consistent cash flows, no real root) the calculator confidently displays a wrong rate/period instead of an error |
+| PERF-1 | Performance | **Medium** | [vite.config.ts](../vite.config.ts) build output | Single `index-*.js` chunk: **889.6 kB (262.2 kB gzip)**; Vite itself warns at build time | One changed line anywhere invalidates the entire cached bundle for returning users; initial parse cost on low-end devices; fix does **not** require abandoning static imports (see recommendation) |
+| PERF-2 | Performance | Low | [CreditCardCalculator.tsx:161-196](../src/components/CreditCardCalculator.tsx), [AutoLoanCalculator.tsx:89+](../src/components/AutoLoanCalculator.tsx), [MortgageCalculator.tsx](../src/components/MortgageCalculator.tsx) | Amortization tables render up to 600 (credit card) / 360+ (mortgage) `TableRow`s with no virtualization or pagination in the monthly view | Noticeable render jank on tablets (the primary classroom device per README's iPad instructions); yearly view mitigates but monthly is one click away |
+| PERF-3 | Performance | Low | [RetirementPlanner.tsx:99-108](../src/components/RetirementPlanner.tsx) | Chart loop calls `simulate(y)` (itself O(y·12)) for every year → O(years²) total, plus a second `simulate(elapsed)` per point | Harmless at realistic scale (~24k iterations for 65-year span) but a quadratic pattern worth a comment or single-pass rewrite if anyone extends it |
+| SEC-2 | Security | Low | [HP12cCalculator.tsx:35](../src/components/HP12cCalculator.tsx) | `window.open('https://mscottsewell.github.io/HP12c/', '_blank')` without `'noopener'`; iframe on line 44 has no `sandbox` attribute | `window.open` (unlike anchor `target="_blank"`) does **not** default to noopener — the opened page gets `window.opener`. Same-owner destination today, but a compromised or transferred HP12c repo could redirect this app (reverse tabnabbing) |
+| SEC-3 | Security | Low | [src/components/ui/chart.tsx:81](../src/components/ui/chart.tsx) | `dangerouslySetInnerHTML` in `ChartStyle` — and the module is **imported by nothing** (grep confirms zero consumers) | Input is developer-authored config today, but it's injectable CSS sitting in the tree; simplest mitigation is deleting the unused file |
+| SEC-4 | Security/PWA | Low | [vite.config.ts:51-66](../vite.config.ts) | Runtime `CacheFirst` rule for `fonts.googleapis.com` with `cacheableResponse: { statuses: [0, 200] }`, but the app loads no Google Fonts (no link in `index.html`, none in CSS) | Dead config; caching opaque (status 0) responses for a year is the classic cache-poisoning-adjacent pattern — remove rather than audit |
+| ST-3 | Stability/TS | Low | [src/lib/formatters.ts:30](../src/lib/formatters.ts) | `return cleanValue as any` — `parseFormattedNumber` can return the string `'-'` or `'-.'` typed as `NumericOrEmpty` | Type lie; downstream `isValidNumber` happens to reject it and `toNumber` returns 0, so no runtime bug today — but the escape hatch invites one |
+| ST-8 | Consistency | Low | [App.tsx:42-52](../src/App.tsx) + component sources | Only 3 of 9 calculators persist inputs (`autoloan-calculator`, `creditcard-calculator`, `mortgage-calculator`); README claims "Your inputs are saved automatically" ([README.md:227](../README.md)) | Inconsistent UX and a false product claim; Retirement/Compound/Inflation/Insurance/TVM lose state on tab close |
+| ST-9 | Stability | Low | [src/hooks/useLocalStorage.ts:20-27](../src/hooks/useLocalStorage.ts) | The persist `useEffect` writes the **default value** to storage on first mount (before any user edit), and there is no `storage`-event sync between tabs | First-visit writes are harmless but mask "never used" state; two open tabs of the same calculator silently overwrite each other (last-write-wins per keystroke) |
+| ST-10 | Correctness | Low | [CompoundInterestCalculator.tsx:111-112](../src/components/CompoundInterestCalculator.tsx) | `totalInterest = finalAmount - totalDeposits` can be negative at 0% rate + rounding; results card shows it unguarded (chart clamps with `Math.max(0, …)` but results don't) | A student can see "-$0" or small negative interest; trivial fix, visible confusion |
+| A11Y-1 | Accessibility | Low | All calculator charts | recharts `ResponsiveContainer` output has no `role="img"`/`aria-label` and no text alternative for the data | Screen-reader users get nothing from the primary visualization; each chart already has an adjacent results card, so a one-line `aria-label` on the wrapper is 90% of the fix |
+| A11Y-2 | Accessibility | Low | e.g. [CompoundInterestCalculator.tsx:204-215](../src/components/CompoundInterestCalculator.tsx) and all `type="number"` inputs | Native `type="number"` inputs change value on mouse-wheel scroll while focused | Classic accidental-input-change trap on a page that scrolls; students silently change "Interest Rate" while scrolling the page |
+| DEP-1 | Dependencies | Low | [package.json:41](../package.json) | `"path": "^0.12.7"` in devDependencies — this is a userland npm shim of the Node built-in; `vite.config.ts` resolves the real built-in anyway | Unmaintained package (last publish ~2015) sitting in the tree for no reason; also `react-is` and `workbox-window` have zero direct imports in `src/` (transitive needs are declared by their consumers, not by the app) |
+
+---
+
+## 3. Recommended Changes (hand-off-ready)
+
+Each item below is written so a junior developer or a smaller model can execute it without further context. Do them as independent commits in the order listed within each priority band (§4).
+
+### ST-1 — Decide the PWA's fate (pick exactly one option)
+
+**Files:** `src/main.tsx`, `vite.config.ts`, `README.md`
+
+The repo currently does both of these, which cannot coexist:
+- `vite.config.ts:12-71` — VitePWA generates `sw.js` + auto-injects `registerSW.js` into `dist/index.html` (verified in a fresh build).
+- `src/main.tsx:21-47` — `purgeServiceWorkers()` unregisters every SW, deletes every cache, and forces one reload per browser session.
+
+**Option A — restore the PWA (recommended; README markets it heavily):**
+1. In `src/main.tsx`, delete the entire `purgeServiceWorkers` function (lines 11-45) and its call site (line 47). The block comment explains it existed for the WebContainer dev sandbox; VitePWA's `devOptions.enabled: false` already keeps the SW out of `npm run dev`, so the purge is only "protecting" production, where it instead breaks the feature.
+2. Rebuild (`npm run build`) and verify `dist/index.html` still contains the `registerSW.js` script tag.
+3. Verify with `npm run pwa:preview`: load the page, DevTools → Application → Service Workers shows an **activated, non-purged** worker after reload; toggle offline and confirm the app still loads.
+
+**Option B — remove the PWA entirely:**
+1. Delete the `VitePWA(...)` plugin block from `vite.config.ts` and the `vite-plugin-pwa`/`workbox-window` dev deps.
+2. Keep `purgeServiceWorkers()` for one release (it cleans up existing installs), then delete it.
+3. Rewrite README's "Install as an App"/offline sections.
+
+**Acceptance criteria:** a fresh production visit performs no self-reload (Network tab shows one document load); either offline mode works (A) or nothing registers a SW (B); README matches reality.
+
+### SEC-1 + ST-2 — Validate persisted state once, delete every `data!`
+
+**Files:** `src/hooks/useLocalStorage.ts`, then the three consumers.
+
+1. Extend the hook with an optional validator, defaulting to accept:
+
+```ts
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  validate?: (parsed: unknown) => parsed is T
+): [T, Dispatch<SetStateAction<T>>] {
+  const getStoredValue = () => {
+    if (typeof window === 'undefined') return defaultValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      if (!item) return defaultValue;
+      const parsed: unknown = JSON.parse(item);
+      if (validate && !validate(parsed)) return defaultValue;  // schema drift → fall back
+      return parsed as T;
+    } catch { return defaultValue; }
+  };
+  // ... rest unchanged
+```
+
+2. In each consumer, pass a small guard. Example for `AutoLoanCalculator.tsx`:
+
+```ts
+const isAutoLoanData = (v: unknown): v is AutoLoanData =>
+  typeof v === 'object' && v !== null &&
+  ['loanAmount', 'interestRate', 'loanTerm'].every(
+    k => { const x = (v as Record<string, unknown>)[k]; return x === '' || typeof x === 'number'; }
+  );
+```
+
+3. Because the hook now always returns a valid `T`, mechanically replace every `data!.` with `data.` and every `data?.` with `data.` in `AutoLoanCalculator.tsx`, `CreditCardCalculator.tsx`, `MortgageCalculator.tsx`, `TimeValueOfMoneyCalculator.tsx` (TVM uses plain `useState` — its `data!` assertions are already unnecessary and can be dropped with no other change). Also delete the dead `safeCurrent` fallback object at `CreditCardCalculator.tsx:224-230`.
+
+**Acceptance criteria:** `grep -rn 'data!' src/` returns zero hits; `npm run typecheck` passes; manually setting `localStorage['autoloan-calculator'] = '"garbage"'` and reloading shows defaults instead of a crash.
+
+### ST-4 — Make Compound Interest honor the frequency selector
+
+**File:** `src/components/CompoundInterestCalculator.tsx:84-155`
+
+Choose the simpler correct model: when frequency = Annually **and** deposit frequency = monthly, either (a) compound deposits annually using end-of-year lump sums (`12 × additionalDeposit` per year at annual rate), or (b) — simpler and defensible — state in the UI that deposits always compound at the deposit frequency. Recommended: (a), because the control claims to change the math.
+
+Concrete change for (a): in both `calculate()` and the chart loop, replace the deposit branch's hardcoded `r / 12` with a rate/period pair derived from `data.compoundingFrequency`:
+
+```ts
+// n = data.compoundingFrequency (1 or 12)
+const periodsPerYear = data.depositFrequency === 'monthly' ? 12 : 1
+const effPeriodRate = Math.pow(1 + r / n, n / periodsPerYear) - 1  // equivalent rate per deposit period
+// then: FV = deposit * ((1+effPeriodRate)^(periodsPerYear*t) - 1) / effPeriodRate  (0-rate branch unchanged)
+```
+
+Also clamp the results card: `totalInterest: Math.max(0, finalAmount - totalDeposits)` (fixes ST-10 in the same commit).
+
+**Acceptance criteria (hand-check):** principal 0, deposit $100/mo, 12% annual, 1 year — Monthly compounding → $1,268.25; Annual compounding → $1,268.25 must **change** to the annually-equivalent figure ($1,261.62 with the effective-rate method). Both must equal the deposit sum ($1,200) at 0% rate.
+
+### ST-5 — Credit Card: surface the 600-month cap and fix the minimum-payment naming
+
+**File:** `src/components/CreditCardCalculator.tsx`
+
+1. After the `while` loop (line 177), add: `if (currentBalance > 0.01) { setError('This balance won\'t be paid off within 50 years at this payment. Showing the first 50 years only.'); }` — keep the results but with the warning visible (do **not** early-return; the truncated schedule is still educational).
+2. The `minimumPayment` field is a **dollar** floor (used as `Math.max(minimumPayment, interest + 1% of balance)` at line 134-137). Fix the two validation messages at lines 215-217 that call it a "percentage", and check the input's `Label` text renders "Minimum Payment ($)" not "%".
+
+**Acceptance criteria:** balance $5,000, APR 30%, fixed payment $126 → warning appears (interest ≈ $125/mo); the word "percentage" no longer appears in this file except where a true percentage is meant.
+
+### ST-6 — Inflation: reuse the shared validator
+
+**File:** `src/components/InflationCalculator.tsx:42-49`
+
+Replace the local `isValidNumber`-only check with the existing `validateCalculatorInputs` from `@/lib/calculator-validation` (it already rejects `<= 0`) for `currentAmount` and `years`; add one explicit range check `if (toNumber(data.inflationRate) <= -100) return 'Inflation rate must be greater than -100%'` (negative rates are legitimate — deflation — so don't force positive).
+
+**Acceptance criteria:** amount 0 → error, not NaN; rate −100 → error, not Infinity; rate −2 → valid deflation result; existing happy path unchanged.
+
+### ST-7 — TVM: fail loudly when the solver doesn't converge
+
+**File:** `src/components/TimeValueOfMoneyCalculator.tsx:117-176`
+
+In `solveForRate` and `solveForPeriods`, track convergence and return `NaN` on failure instead of the last iterate:
+
+- On loop exit (max iterations reached or `df` underflow `break`), re-evaluate the residual `f`; if `Math.abs(f) > 0.01` return `NaN`.
+- The existing caller already guards `if (solvedValue === null || isNaN(solvedValue) || !isFinite(solvedValue))` (verify at the `switch` result handling around line 323) — if it doesn't, add that guard with the error message `'No solution found for these inputs — check your cash-flow signs (money out is negative, money in is positive).'`
+
+**Acceptance criteria:** PV = 1000, PMT = 100, FV = 5000, N = 10 (all positive — no sign change, no root) → error message, not a number. Standard case PV = −5000, PMT = −6000, FV = 1,000,000, solve I/Y over 20 → still returns ≈ 8% region result.
+
+### PERF-1 — Vendor chunk split (keeps static imports)
+
+**File:** `vite.config.ts`
+
+Add to `defineConfig`:
+
+```ts
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        react: ['react', 'react-dom'],
+        recharts: ['recharts'],
+      },
+    },
+  },
+},
+```
+
+This is a pure build-output change — **no `React.lazy`, no dynamic imports**, so the WebContainer constraint documented in `App.tsx:18-21` is untouched. React/recharts (~600 kB of the 890) become long-lived cached chunks; app-code edits only invalidate the small app chunk.
+
+**Acceptance criteria:** `npm run build` emits ≥3 JS chunks; the largest is under 500 kB minified (warning gone or reduced); `npm run pwa:preview` loads and all 9 tabs render.
+
+### SEC-2 — HP-12C embed hardening
+
+**File:** `src/components/HP12cCalculator.tsx`
+
+1. Line 35: `window.open('https://mscottsewell.github.io/HP12c/', '_blank', 'noopener,noreferrer')`.
+2. Line 44-50: add `sandbox="allow-scripts allow-same-origin"` to the `<iframe>` (the calculator needs scripts; it does not need popups, top-navigation, or forms).
+
+**Acceptance criteria:** pop-out still opens the calculator; embedded calculator still functions (keys click, display updates); `window.opener` is `null` in the popped-out tab's console.
+
+### SEC-3 / SEC-4 / DEP-1 — Dead-weight removal (one commit)
+
+1. Delete `src/components/ui/chart.tsx` (zero importers — verify first with `grep -rn "ui/chart" src/`).
+2. Delete the `runtimeCaching` block for `fonts.googleapis.com` in `vite.config.ts:51-66` (no Google Fonts are loaded).
+3. `npm uninstall path` (devDependency shim of a Node built-in). Optionally audit `react-is` and `workbox-window` — neither is imported in `src/`; remove if `npm run build` and `npm run dev` still pass without them.
+4. While in `src/assets/images/`: `college-logo.svg` and `FHU_COB.svg` have no importers (`BellTower.svg` is the only one used, in `App.tsx:16`) — delete or consciously keep.
+
+**Acceptance criteria:** `npm run typecheck`, `npm run build`, `npm run dev` all pass; bundle size does not increase.
+
+### ST-3 — Remove the `as any` in `parseFormattedNumber`
+
+**File:** `src/lib/formatters.ts:26-33`
+
+The `'-'`/`'-.'` passthrough exists so users can type a leading minus. Fix the type instead of lying: change the return type to `NumericOrEmpty | '-' | '-.'`, **or** simpler — return `''` for those partials and accept that a lone `-` clears the field (check each text-input consumer's UX before choosing). Either way, delete `as any`.
+
+**Acceptance criteria:** `grep -n "as any" src/lib/formatters.ts` → no hits; typing `-5000` into TVM's Present Value field still works.
+
+### ST-8 — Persistence consistency + honest README
+
+Add `useLocalStorage` (with validators per SEC-1) to the six non-persisting calculators, keys: `retirement-planner`, `compound-calculator`, `inflation-calculator`, `insurance-calculator`, `tvm-calculator` (HP-12C has no inputs to persist). Or, if persistence is deliberately scoped, change README line 227 ("Your inputs are saved automatically") to name the three calculators that persist.
+
+**Acceptance criteria:** every calculator with inputs either persists across a reload or the README no longer claims it does.
+
+### ST-9 — `useLocalStorage` polish (optional, do with SEC-1)
+
+Skip the initial write when the stored value equals the default (track a `hydrated` ref), and add a `storage` event listener to sync across tabs. Low value for a classroom app — acceptable to mark "won't fix" explicitly.
+
+### A11Y-1 / A11Y-2 — Accessibility quick wins
+
+1. On each chart wrapper `div` (e.g. `CompoundInterestCalculator.tsx:313`), add `role="img"` and a computed `aria-label`, e.g. `` aria-label={`Growth chart: ${formatCurrency(results.finalAmount)} after ${data.years} years`} ``.
+2. Global fix for wheel-changes-number: in `src/index.css` add nothing — instead add one shared handler in `src/components/ui/input.tsx`: `onWheel={(e) => (e.target as HTMLElement).blur()}` applied when `type === 'number'`.
+
+**Acceptance criteria:** VoiceOver/NVDA announces each chart; scrolling the page with cursor over a focused numeric input no longer changes its value.
+
+---
+
+## 4. Prioritized Backlog
+
+**Quick wins (≤1 hour each, do first):**
+1. ST-1 Option A — delete `purgeServiceWorkers` (biggest user-visible payoff per line changed)
+2. PERF-1 — `manualChunks` split
+3. SEC-2 — `noopener` + iframe `sandbox`
+4. SEC-3/SEC-4/DEP-1 — dead-weight deletion commit
+5. ST-10 — clamp negative interest display (fold into ST-4 if doing both)
+6. ST-6 — Inflation validation
+7. ST-5 — credit-card cap warning + label fix
+
+**Medium (half-day):**
+8. SEC-1 + ST-2 — validated `useLocalStorage` + purge all `data!` (touch 4 files, mechanical)
+9. ST-7 — TVM solver convergence guards
+10. A11Y-1/A11Y-2
+11. ST-3 — formatter type fix
+
+**Larger / needs a product decision:**
+12. ST-4 — compound-frequency math model (needs agreement on model (a) vs (b))
+13. ST-8 — persistence rollout to all calculators (or README correction — 5 minutes if you choose honesty over feature)
+14. PERF-2 — table pagination/virtualization for monthly amortization views (only if tablet jank is actually reported)
+
+---
+
+## 5. Mismatches: `.github/copilot-instructions.md` vs. actual code
+
+| Claim in copilot-instructions.md | Reality | Action |
+|---|---|---|
+| "`src/App.tsx` … **lazy-loads calculators with `Suspense`**" (§ High-level architecture) | All 9 calculators are **statically imported** ([App.tsx:18-30](../src/App.tsx)) with a comment explicitly explaining why lazy-loading was removed | Update the doc; this is the exact trap the App.tsx comment warns future contributors about |
+| "`.github/workflows/deploy.yml` is the active … pipeline" | The file exists, **and** `package.json` also has a `gh-pages -d dist` deploy script — two deploy paths | Doc should state which is canonical (the workflow) and that `npm run deploy` is the manual fallback, or the script should be removed |
+| "Persistence is local-state-first: `useLocalStorage` … used by calculators that should keep inputs (not all calculators use it)" | Technically true, but "should" is doing heavy lifting: only 3 of 9 use it, and the README contradicts both (see ST-8) | Align doc + README + code (pick per ST-8) |
+| README (not copilot-instructions, but same class of drift): "State Management: React hooks with **GitHub Spark KV store**" ([README.md:138](../README.md)) | Spark's `useKV` was replaced by `useLocalStorage` (the hook's own docstring says so) | Update README |
+| README: "six comprehensive financial calculators" ([README.md:74](../README.md)) | There are **nine** tabs (Retirement, Compound, Inflation, Insurance, TVM, Credit Card, Auto Loan, Mortgage, HP-12C) | Update README |
+| README: "Offline Access … even without internet connection" | Broken by ST-1 until resolved | Resolve ST-1 first, then doc |
+
+---
+
+*End of review. No application source was modified. All build artifacts referenced (bundle sizes, dist/index.html contents) come from `npm run build` executed on 2026-07-02.*

--- a/docs/PAYCHECK-ESTIMATOR-SPEC.md
+++ b/docs/PAYCHECK-ESTIMATOR-SPEC.md
@@ -1,0 +1,457 @@
+# Paycheck Estimator — Implementation Specification
+
+**Status:** Ready to build. **Deliverable of this spec:** none of the code below exists yet; an implementer (human or model) builds it exactly as specified.
+**Date:** 2026-07-02 (all tax figures are **tax year 2026**).
+**Audience for the feature:** university students planning for their first job.
+**Audience for this document:** an implementing agent that will not infer missing steps — everything is explicit.
+
+---
+
+## 0. What we're building, in one paragraph
+
+A new calculator tab, **"Paycheck"**, that takes a gross salary (or hourly rate) and estimates **take-home pay** after federal income tax, Social Security, Medicare, a selected state's income tax, and optional pre-tax deductions (401(k) %, health premiums), plus optional extra withholding. It shows the results per pay period and annualized, an effective-tax-rate figure, a recharts breakdown of where every dollar goes, a monthly budget snapshot, and a "Key Lesson" explaining why the first paycheck is smaller than salary ÷ 12. It follows every existing convention in this repo: `NumericOrEmpty` inputs, validate-first flow, `CalculateButton`, `useLocalStorage`, shared formatters, no new dependencies.
+
+---
+
+## 1. Reference-implementation comparison
+
+Two existing calculators were evaluated (fetched 2026-07-02):
+
+| Aspect | [digitalcalculators.net/paycheck-calculator](https://digitalcalculators.net/paycheck-calculator/) | [easybudgetplanners.com/paycheck-calculator](https://easybudgetplanners.com/paycheck-calculator) |
+|---|---|---|
+| Income entry | Salary, hourly (rate × hrs/wk × 52), or raw gross-per-check | Salary or hourly, plus overtime hours at 1.5×/2.0× |
+| Filing statuses | Single, MFJ, MFS, HoH | Single, MFJ, HoH |
+| State handling | Rate-method picker (midpoint/low/high/custom) or "no state tax" | Full 50-state + DC selector |
+| Pre-tax | Per-paycheck dollar amount (401k/HSA/insurance lumped) | Itemized: health/dental/vision, HSA, FSA, 401(k) % with limit warning |
+| After-tax | Local tax %, additional deductions | Roth 401(k), loans, garnishments, union dues |
+| Extras | YTD wages input (respects SS cap mid-year), worked example, scenario testing | Dependent tax credits, tooltips, FAQ, effective-vs-marginal explainer |
+| Cited sources | IRS IR-2025-103, Rev. Proc. 2025-32 PDF, SSA wage-base page, SSA 2026 COLA fact sheet, IRS Topic 560 | States 2026 brackets and limits inline, fewer explicit citations |
+| Disclaimers | Strong: "results are approximations… W-4 settings, credits, local rules" | Strong: "educational purposes only… not tax advice" |
+
+**Cautionary note:** easybudgetplanners displayed a **stale 401(k) limit ($23,500 — the 2025 figure)** at fetch time; the correct 2026 elective-deferral limit is **$24,500** ([IRS newsroom](https://www.irs.gov/newsroom/401k-limit-increases-to-24500-for-2026-ira-limit-increases-to-7500), [Notice 2025-67](https://www.irs.gov/pub/irs-drop/n-25-67.pdf)). This is exactly why our data file must carry dated citations (§3).
+
+**Adopt for our student audience:**
+- Salary **and** hourly entry with pay-frequency selector (both sites; core need for first-job planning).
+- Filing status limited to **Single, Married Filing Jointly, Head of Household** (easybudgetplanners' set — MFS is rare for students and adds a bracket table for little value).
+- Full 50-state + DC `Select` (easybudgetplanners) but with our simplified three-tier rate model (§3.3) rather than per-state brackets.
+- 401(k) as a **percent of gross** with the $24,500 limit warning (easybudgetplanners).
+- Effective-vs-marginal rate explainer — perfect "Key Lesson" material.
+- Strong dated citations in the data file (digitalcalculators' habit).
+
+**Skip (scope creep for v1):**
+- Overtime multipliers, YTD wages/mid-year SS-cap proration, after-tax deductions (Roth, garnishments), dependent tax credits, local tax %, itemized-deduction entry, MFS status. Each is listed in §8 as a possible v2 item. Rationale: a student modeling a first job has a single full-year salary; the marginal educational value of these inputs is low and each one doubles the explanation burden.
+
+---
+
+## 2. Feature scope & UX
+
+### 2.1 Registry metadata
+
+| Property | Value |
+|---|---|
+| `id` | `'paycheck'` |
+| `labels.short` | `'Paycheck'` |
+| `labels.full` | `'Paycheck Estimator'` |
+| `icon` | `Wallet` from `@phosphor-icons/react` (confirmed to exist in the installed icon set; fallback if ever missing: `Money`) |
+| Tab position | **Second**, immediately after `'retirement'` — "what will my job actually pay me" is the most immediately relatable question for the audience |
+| Component | `PaycheckCalculator` in `src/components/PaycheckCalculator.tsx` |
+| localStorage key | `'paycheck-calculator'` |
+
+### 2.2 Inputs
+
+State shape (persisted via `useLocalStorage<PaycheckData>('paycheck-calculator', DEFAULTS)`):
+
+```ts
+type PayMode = 'salary' | 'hourly'
+type PayFrequency = 'annual' | 'monthly' | 'semimonthly' | 'biweekly' | 'weekly'
+type FilingStatus = 'single' | 'marriedJoint' | 'headOfHousehold'
+
+interface PaycheckData {
+  payMode: PayMode                    // Select: "Annual salary" | "Hourly wage"
+  annualSalary: NumericOrEmpty        // shown when payMode === 'salary'; text input w/ commas
+  hourlyRate: NumericOrEmpty          // shown when payMode === 'hourly'; number input, step 0.25
+  hoursPerWeek: NumericOrEmpty        // shown when payMode === 'hourly'; number input, default 40
+  payFrequency: PayFrequency          // Select — controls the per-period OUTPUT display
+  filingStatus: FilingStatus          // Select
+  stateCode: string                   // Select, 50 states + 'DC'; default 'TN'
+  retirement401kPercent: NumericOrEmpty  // % of gross, number input, default 5
+  healthPremiumMonthly: NumericOrEmpty   // $/month pre-tax (Section 125), commas input, default 0
+  additionalWithholding: NumericOrEmpty  // $/paycheck extra federal withholding, default 0
+}
+
+const DEFAULTS: PaycheckData = {
+  payMode: 'salary', annualSalary: 55000, hourlyRate: 20, hoursPerWeek: 40,
+  payFrequency: 'biweekly', filingStatus: 'single', stateCode: 'TN',
+  retirement401kPercent: 5, healthPremiumMonthly: 0, additionalWithholding: 0,
+}
+```
+
+Default state is **TN** (the app's home institution is in Tennessee, a no-income-tax state — itself a teaching moment the Key Lesson can reference).
+
+Input conventions (copy the patterns from `CompoundInterestCalculator.tsx:188-265` exactly):
+- Currency-like fields (`annualSalary`, `healthPremiumMonthly`, `additionalWithholding`): `type="text"`, `value={formatNumberWithCommas(...)}`, `onChange` through `parseFormattedNumber`.
+- Percent/small-number fields (`hourlyRate`, `hoursPerWeek`, `retirement401kPercent`): `type="number"` with the `''`-preserving onChange (`e.target.value === '' ? '' : Number(e.target.value)`), `%`/unit suffix via the absolute-positioned span pattern where applicable.
+- All `Select`s use `@/components/ui/select`; every input gets a `Label htmlFor` pairing.
+- The grid: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4`. Show/hide the salary vs hourly fields by conditional render on `payMode` (same technique as `CreditCardCalculator`'s `paymentType` conditional fields).
+
+### 2.3 Validation (validate-first, early return — the repo pattern)
+
+Run in this order; set the first failing message into the `error` state and return:
+
+1. `payMode === 'salary'`: `annualSalary` must be a valid number `> 0` and `≤ 10,000,000` ("Please enter an annual salary between $1 and $10,000,000").
+2. `payMode === 'hourly'`: `hourlyRate` valid `> 0` and `≤ 5,000`; `hoursPerWeek` valid `> 0` and `≤ 100`.
+3. `retirement401kPercent`: empty is allowed (treat as 0 via `toNumber`); if present, must be `≥ 0` and `≤ 100`.
+4. `healthPremiumMonthly`, `additionalWithholding`: empty allowed (→ 0); if present `≥ 0`.
+5. Cross-field: total annual pre-tax deductions must be `< gross` ("Pre-tax deductions can't exceed your gross pay").
+6. Warning (non-blocking — render as a second, non-destructive `Alert` below results, do **not** abort): if `401(k) annual dollars > 24500`, show "Heads up: your 401(k) contribution exceeds the 2026 IRS limit of $24,500 — payroll would stop it there. We've capped it in this estimate." **and cap the value at $24,500 in the math.**
+
+### 2.4 Outputs (results cards)
+
+Two result cards side by side (`grid grid-cols-1 md:grid-cols-2 gap-6`), values from a `results` state object set by `calculate()`:
+
+**Card 1 — "Your Paycheck" (per selected pay period, using `formatCurrency(x, true)` i.e. cents):**
+| Row | Value |
+|---|---|
+| Gross pay | `grossAnnual / periodsPerYear` |
+| 401(k) contribution | pre-tax, shown as a positive deduction |
+| Health premium | pre-tax |
+| Federal income tax | |
+| Social Security (6.2%) | |
+| Medicare (1.45%+) | |
+| State income tax ({state name}) | show "$0 — {state} has no income tax 🎉" when tier is `none` |
+| Additional withholding | only render the row if > 0 |
+| **Net take-home** | bold, `currency-green` class like siblings |
+
+**Card 2 — "The Big Picture" (annualized, whole dollars):**
+| Row | Value |
+|---|---|
+| Gross annual income | |
+| Total taxes | federal + SS + Medicare + state |
+| Total pre-tax savings/benefits | 401(k) + premiums |
+| Net annual take-home | |
+| **Effective tax rate** | `totalTaxes / grossAnnual`, one decimal, e.g. "16.0%" |
+| Monthly take-home | `netAnnual / 12` — bridges to the budget snapshot |
+
+**Monthly budget snapshot** (third card, full width, below the chart): apply the 50/30/20 rule to monthly take-home: Needs `× 0.50`, Wants `× 0.30`, Savings & debt `× 0.20`, each as a labeled row with `formatCurrency`. One sentence of framing: "A common starting rule of thumb — adjust to your life."
+
+### 2.5 Chart
+
+A donut breakdown of annual gross using recharts `PieChart` (already in the bundle; `MortgageCalculator` does not use Pie but recharts exports it — no new dependency):
+
+- Slices: Net take-home, Federal tax, Social Security, Medicare, State tax (omit when 0), 401(k), Health premiums (omit when 0), Additional withholding (omit when 0).
+- Colors from `CHART_COLORS` in `@/lib/chart-colors` (net = `emerald`, taxes = `blue`/`orange`/`red` family, pre-tax = `violet` — implementer picks from the existing palette constants only; open that file and use what exists).
+- Tooltip: `formatter={(v: number, name: string) => [formatCurrency(v), name]}`.
+- Wrapper: `<div className="h-60 sm:h-80 w-full" role="img" aria-label={...}>` with a computed label like "Paycheck breakdown: {formatCurrency(netAnnual)} take-home from {formatCurrency(grossAnnual)} gross".
+- Layout position: chart card sits in the same `md:grid-cols-5` split used by `CompoundInterestCalculator.tsx:278-346` (results 2 cols, chart 3 cols) — reuse that structure verbatim, with the "Big Picture" card stacked under "Your Paycheck".
+
+### 2.6 Hero banner and Key Lesson
+
+Hero banner: copy the exact structure of `CompoundInterestCalculator.tsx:165-185` (gradient div + dot pattern + icon chip + title/subtitle). Suggested copy:
+- Title: `Your Salary ≠ Your Paycheck 💰`
+- Subtitle: `That $55,000 offer letter doesn't mean $4,583 a month in your pocket. See where every dollar actually goes — before your first payday surprises you.`
+- Gradient: `linear-gradient(135deg, oklch(0.42 0.14 160), oklch(0.22 0.09 160))` (green family — money; distinct from siblings' blue/orange).
+- Icon: `Wallet` size 24 weight fill.
+
+Key Lesson card (copy structure from `CompoundInterestCalculator.tsx:349-364`): title `💡 Key Lesson`, body explaining: (1) gross vs net, (2) FICA is 7.65% off the top for almost everyone and funds Social Security/Medicare, (3) marginal vs effective rate — "landing in the 22% bracket" does not mean paying 22% on everything, (4) pre-tax 401(k) dollars lower your tax bill today, so the take-home cost of saving $100 is less than $100.
+
+**Disclaimer block (required, non-negotiable):** a muted paragraph directly under the results, plus one line in the Key Lesson card:
+> *Estimates for education only. Actual withholding depends on your W-4, tax credits, local/city taxes, benefit plan details, and state rules we simplify here (see the note next to your state). Not tax advice.*
+
+---
+
+## 3. Data model — `src/lib/paycheck-tax-tables.ts`
+
+New file mirroring the documentation pattern of `src/lib/insurance-rates.ts` (header comment with dated sources, then typed exported tables, then small pure lookup functions).
+
+### 3.1 File header (copy-paste ready — implementer keeps citations verbatim)
+
+```ts
+/**
+ * 2026 U.S. payroll-tax tables for the Paycheck Estimator (educational).
+ *
+ * Everything here is TAX YEAR 2026. When updating for a new year, change the
+ * numbers AND the source list AND the TAX_YEAR constant together.
+ *
+ * SOURCES:
+ *  • Federal brackets & standard deduction — IRS Rev. Proc. 2025-32
+ *    (https://www.irs.gov/pub/irs-drop/rp-25-32.pdf) as summarized by
+ *    IRS Newsroom "tax inflation adjustments for tax year 2026"
+ *    (https://www.irs.gov/newsroom/irs-releases-tax-inflation-adjustments-for-tax-year-2026-including-amendments-from-the-one-big-beautiful-bill)
+ *    and Tax Foundation "2026 Tax Brackets"
+ *    (https://taxfoundation.org/data/all/federal/2026-tax-brackets/).
+ *  • Social Security wage base ($184,500) — SSA 2026 COLA fact sheet
+ *    (https://www.ssa.gov/oact/cola/cbb.html).
+ *  • Medicare rates & Additional Medicare thresholds — IRS Topic 560
+ *    (https://www.irs.gov/taxtopics/tc560).
+ *  • 401(k) elective-deferral limit ($24,500) — IRS Notice 2025-67
+ *    (https://www.irs.gov/pub/irs-drop/n-25-67.pdf).
+ *  • State rates — Tax Foundation "2026 State Income Tax Rates and Brackets"
+ *    (https://taxfoundation.org/data/all/state/state-income-tax-rates-2026/).
+ *    Progressive states are approximated by a single flat rate (see StateTaxInfo);
+ *    this is an ESTIMATE ONLY and each such state is flagged in the UI.
+ *
+ * Simplifications (must stay documented in the calculator UI):
+ *  – Standard deduction only (no itemizing, no credits, no dependents).
+ *  – No local/city income taxes. No SDI/SUI employee taxes.
+ *  – State tax = flat/approximated rate on (gross − pre-tax deductions);
+ *    state-specific deductions/exemptions are ignored.
+ */
+export const TAX_YEAR = 2026
+```
+
+### 3.2 Federal tables (numbers verified 2026-07-02; one flagged discrepancy)
+
+```ts
+export type FilingStatus = 'single' | 'marriedJoint' | 'headOfHousehold'
+
+// Marginal brackets: [lower bound of bracket, rate]. Applied progressively (§4.2).
+// Upper bound of bracket i is (lower bound of bracket i+1); last bracket is unbounded.
+export const FEDERAL_BRACKETS: Record<FilingStatus, Array<[number, number]>> = {
+  single: [
+    [0, 0.10], [12_400, 0.12], [50_400, 0.22], [105_700, 0.24],
+    [201_775, 0.32], [256_225, 0.35], [640_600, 0.37],
+  ],
+  marriedJoint: [
+    [0, 0.10], [24_800, 0.12], [100_800, 0.22], [211_400, 0.24],
+    [403_550, 0.32], [512_450, 0.35], [768_700, 0.37],  // TODO(verify): IRS newsroom says $768,600, Tax Foundation says $768,700 — confirm against Rev. Proc. 2025-32 §2.01 table 3 and fix if needed
+  ],
+  headOfHousehold: [
+    [0, 0.10], [17_700, 0.12], [67_450, 0.22], [105_700, 0.24],
+    [201_775, 0.32], [256_200, 0.35], [640_600, 0.37],
+  ],
+}
+
+export const STANDARD_DEDUCTION: Record<FilingStatus, number> = {
+  single: 16_100,
+  marriedJoint: 32_200,
+  headOfHousehold: 24_150,
+}
+
+export const FICA = {
+  socialSecurityRate: 0.062,
+  socialSecurityWageBase: 184_500,
+  medicareRate: 0.0145,
+  additionalMedicareRate: 0.009,
+  additionalMedicareThreshold: {
+    single: 200_000, marriedJoint: 250_000, headOfHousehold: 200_000,
+  } as Record<FilingStatus, number>,
+}
+
+export const LIMIT_401K = 24_500
+```
+
+**Additional Medicare tax is IN SCOPE.** Decision and rationale: it costs ~4 lines of math, the threshold teaches "taxes have cliffs and caps", and without it a $250k test case is silently wrong. (Employers withhold the extra 0.9% above $200k regardless of filing status, but for an annual *estimate* we use the filing-status liability thresholds above — simpler to explain and matches year-end truth better.)
+
+### 3.3 State model — decision and table
+
+**Decision: all 50 states + DC via a three-tier flat-rate model.**
+
+- Tier `none` (9 states): AK, FL, NV, NH, SD, TN, TX, WA, WY — $0 state income tax on wages (NH finished repealing its interest/dividends tax in 2025; WA taxes only capital gains, not wages).
+- Tier `flat` (15 states in 2026): the state's actual statutory flat rate — exact, not approximated.
+- Tier `approx` (remaining 26 states + DC, all graduated): a **single representative flat rate** chosen as the rate that applies at ~$50-80k taxable income for a single filer in that state (i.e., the bracket a typical graduate's salary lands in), NOT the top rate. Each `approx` state renders an inline note: *"{State} uses graduated brackets — this is a simplified estimate."*
+
+**Why not full 50-state bracket tables:** ~27 sets of brackets × annual maintenance × state-specific deductions/exemptions that we would *still* be ignoring = large surface area for stale-data bugs (see the $23,500 error on a dedicated paycheck site, §1) with little educational gain for this audience. **Why not "pick your own rate":** students don't know their state's rate — that's the point of the tool.
+
+```ts
+export type StateTaxTier = 'none' | 'flat' | 'approx'
+export interface StateTaxInfo { name: string; tier: StateTaxTier; rate: number }
+
+// rate is the marginal/flat rate as a decimal; 0 for tier 'none'.
+export const STATE_TAX: Record<string, StateTaxInfo> = {
+  AK: { name: 'Alaska', tier: 'none', rate: 0 },
+  FL: { name: 'Florida', tier: 'none', rate: 0 },
+  NV: { name: 'Nevada', tier: 'none', rate: 0 },
+  NH: { name: 'New Hampshire', tier: 'none', rate: 0 },
+  SD: { name: 'South Dakota', tier: 'none', rate: 0 },
+  TN: { name: 'Tennessee', tier: 'none', rate: 0 },
+  TX: { name: 'Texas', tier: 'none', rate: 0 },
+  WA: { name: 'Washington', tier: 'none', rate: 0 },
+  WY: { name: 'Wyoming', tier: 'none', rate: 0 },
+  // Flat-tax states — verified 2026 examples; implementer completes the set (15 total)
+  // from https://taxfoundation.org/data/all/state/state-income-tax-rates-2026/ :
+  KY: { name: 'Kentucky', tier: 'flat', rate: 0.035 },   // reduced from 4.0% for 2026
+  NC: { name: 'North Carolina', tier: 'flat', rate: 0.0399 }, // reduced from 4.25% 1/1/2026
+  MS: { name: 'Mississippi', tier: 'flat', rate: 0.040 }, // phase-down completed
+  OH: { name: 'Ohio', tier: 'flat', rate: 0.0275 },       // flat as of 1/1/2026 (income > $26,050)
+  // TODO(data): remaining flat states (AZ, CO, GA, IA, ID, IL, IN, LA, MI, PA, UT, …
+  //   — confirm the exact 2026 list & rates from the Tax Foundation source above)
+  // TODO(data): all graduated states as tier 'approx' with the representative rate
+  //   at ~$50–80k single taxable income, from the same source. Examples of the
+  //   expected shape (rates MUST be verified before shipping):
+  //   CA: { name: 'California', tier: 'approx', rate: 0.08 },
+  //   NY: { name: 'New York', tier: 'approx', rate: 0.055 },
+  //   VA: { name: 'Virginia', tier: 'approx', rate: 0.0575 },
+}
+```
+
+> **Definition of done for this table:** every US state + DC present (51 entries), zero `TODO(data)` markers remaining, every `flat` rate cross-checked against the Tax Foundation 2026 page (linked in the header) on the day of implementation, and the file's header source list updated with the access date.
+
+### 3.4 Exported pure functions (unit-testable by hand)
+
+```ts
+/** Progressive federal tax on `taxableIncome` (already net of deductions; clamp ≥ 0 upstream). */
+export function federalIncomeTax(taxableIncome: number, status: FilingStatus): number
+
+/** Social Security employee tax: 6.2% of min(ficaWages, wage base). */
+export function socialSecurityTax(ficaWages: number): number
+
+/** Medicare 1.45% of all ficaWages + 0.9% of the amount above the status threshold. */
+export function medicareTax(ficaWages: number, status: FilingStatus): number
+
+/** State tax under the tier model: rate × max(0, stateTaxableIncome). */
+export function stateIncomeTax(stateTaxableIncome: number, stateCode: string): number
+```
+
+No React imports in this file. All functions must return `0` for inputs `≤ 0` (never negative, never NaN).
+
+---
+
+## 4. Math specification
+
+### 4.1 Gross and pre-tax pipeline (exact order — this ordering IS the spec)
+
+```
+grossAnnual   = payMode === 'salary' ? annualSalary
+                                     : hourlyRate × hoursPerWeek × 52
+k401Annual    = min(grossAnnual × retirement401kPercent/100, LIMIT_401K)   // capped, see §2.3(6)
+premiumAnnual = healthPremiumMonthly × 12
+preTaxAnnual  = k401Annual + premiumAnnual
+
+// FICA: Section 125 health premiums are FICA-exempt; traditional 401(k) is NOT.
+ficaWages     = grossAnnual − premiumAnnual
+
+// Federal: both 401(k) and premiums reduce taxable income, then the standard deduction.
+fedTaxable    = max(0, grossAnnual − preTaxAnnual − STANDARD_DEDUCTION[status])
+
+// State (simplified model): pre-tax deductions reduce it; no state standard deduction.
+stateTaxable  = max(0, grossAnnual − preTaxAnnual)
+```
+
+### 4.2 Taxes
+
+```
+federalTax = Σ over brackets i:  rateᵢ × ( min(fedTaxable, upperᵢ) − lowerᵢ )  for fedTaxable > lowerᵢ
+socialSec  = 0.062 × min(ficaWages, 184_500)
+medicare   = 0.0145 × ficaWages + 0.009 × max(0, ficaWages − threshold[status])
+stateTax   = STATE_TAX[stateCode].rate × stateTaxable
+totalTax   = federalTax + socialSec + medicare + stateTax
+```
+
+### 4.3 Net and per-period
+
+```
+periodsPerYear = { annual: 1, monthly: 12, semimonthly: 24, biweekly: 26, weekly: 52 }[payFrequency]
+netAnnual        = grossAnnual − preTaxAnnual − totalTax
+withholdAnnual   = additionalWithholding × periodsPerYear
+netPerPeriodCash = (netAnnual − withholdAnnual) / periodsPerYear   // what hits the bank account
+effectiveRate    = totalTax / grossAnnual                           // grossAnnual > 0 guaranteed by validation
+monthlyTakeHome  = netAnnual / 12                                   // budget snapshot uses this (pre-extra-withholding)
+```
+
+Additional withholding is **not a tax** — the UI must label it "extra federal withholding (you get this back at refund time if overpaid)" and it must NOT be included in `totalTax` or `effectiveRate`.
+
+### 4.4 Worked examples → acceptance assertions
+
+The implementer must reproduce these **by hand from the formulas** before writing UI. Tolerance: ±$1 on annual figures, ±$0.05 on per-period (floating-point + rounding display only — do not round intermediates).
+
+**Example A — baseline salary, no-tax state.** $60,000 salary, Single, TN, 0% 401(k), $0 premium, biweekly.
+- fedTaxable = 60,000 − 16,100 = **43,900**
+- federalTax = 0.10×12,400 + 0.12×(43,900−12,400) = 1,240 + 3,780 = **$5,020**
+- socialSec = 0.062×60,000 = **$3,720**; medicare = 0.0145×60,000 = **$870**; stateTax = **$0**
+- netAnnual = 60,000 − 9,610 = **$50,390**; effectiveRate = 9,610/60,000 = **16.0%**
+- biweekly net = 50,390/26 = **$1,938.08**; monthly take-home = **$4,199.17**
+
+**Example B — pre-tax deductions, flat-tax state.** $85,000 salary, Single, KY (flat 3.5%), 5% 401(k), $200/mo premium, monthly.
+- k401 = 4,250; premium = 2,400; preTax = 6,650
+- ficaWages = 85,000 − 2,400 = **82,600**; fedTaxable = 85,000 − 6,650 − 16,100 = **62,250**
+- federalTax = 1,240 + 0.12×(50,400−12,400) + 0.22×(62,250−50,400) = 1,240 + 4,560 + 2,607 = **$8,407**
+- socialSec = 0.062×82,600 = **$5,121.20**; medicare = 0.0145×82,600 = **$1,197.70**
+- stateTaxable = 78,350; stateTax = 0.035×78,350 = **$2,742.25**
+- totalTax = **$17,468.15**; netAnnual = 85,000 − 6,650 − 17,468.15 = **$60,881.85**
+- effectiveRate = 17,468.15/85,000 = **20.6%**; monthly net = **$5,073.49**
+
+**Example C — above the Social Security cap + Additional Medicare.** $250,000 salary, Single, TX, no pre-tax, annual view.
+- fedTaxable = 233,900
+- federalTax = 1,240 + 4,560 + 0.22×55,300 + 0.24×(201,775−105,700) + 0.32×(233,900−201,775)
+  = 1,240 + 4,560 + 12,166 + 23,058 + 10,280 = **$51,304**
+- socialSec = 0.062×**184,500** = **$11,439** (capped — NOT 0.062×250,000)
+- medicare = 0.0145×250,000 + 0.009×(250,000−200,000) = 3,625 + 450 = **$4,075**
+- netAnnual = 250,000 − 66,818 = **$183,182**; effectiveRate = **26.7%**
+
+**Example D — hourly.** $20/hr, 40 hrs/week, Single, TN, no pre-tax, weekly view.
+- grossAnnual = 20×40×52 = **$41,600**; fedTaxable = 25,500
+- federalTax = 1,240 + 0.12×13,100 = **$2,812**; SS = **$2,579.20**; Medicare = **$603.20**
+- netAnnual = **$35,605.60**; weekly net = 35,605.60/52 = **$684.72**; effectiveRate = **14.4%**
+
+**Example E — edge cases (behavioral assertions):**
+- Salary blank → error `Alert`, no results change.
+- Salary $10,000, Single (below standard deduction): federalTax = **$0** (fedTaxable clamps to 0), SS = $620, Medicare = $145 — FICA still applies. This IS the lesson that FICA has no standard deduction.
+- 401(k) 50% on $60,000 = $30,000 > $24,500 → capped at $24,500 + the non-blocking warning renders.
+- Premiums $6,000/mo on $60,000 salary (72,000 > 60,000) → blocking error from validation rule 5.
+
+---
+
+## 5. Integration steps (exact, ordered)
+
+Execute in order; each step compiles independently.
+
+**Step 1 — data file.** Create `src/lib/paycheck-tax-tables.ts` per §3 (header, tables, four functions). Resolve every `TODO(data)` and the `TODO(verify)` bracket check. Run `npm run typecheck`.
+
+**Step 2 — component.** Create `src/components/PaycheckCalculator.tsx`:
+- Named export `export function PaycheckCalculator()` (all siblings use named exports — see `App.tsx:22-30` import style).
+- Imports (all existing modules, **no new dependencies**):
+  `useState` from react; `useLocalStorage` from `@/hooks/useLocalStorage`; `Card, CardContent, CardHeader, CardTitle` from `@/components/ui/card`; `Input` from `@/components/ui/input`; `Label` from `@/components/ui/label`; `Select, SelectContent, SelectItem, SelectTrigger, SelectValue` from `@/components/ui/select`; `Alert, AlertDescription` from `@/components/ui/alert`; `CalculateButton` from `@/components/ui/calculate-button`; `NumericOrEmpty, isValidNumber, toNumber` from `@/lib/calculator-validation`; `formatCurrency, formatNumberWithCommas, parseFormattedNumber` from `@/lib/formatters`; `CHART_COLORS` from `@/lib/chart-colors`; `PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend` from `recharts`; `Wallet` from `@phosphor-icons/react`; everything needed from `@/lib/paycheck-tax-tables`.
+- Structure top-to-bottom: hero banner → input grid → `CalculateButton` + error `Alert` → results grid (cards + donut) → 401(k)-cap warning `Alert` (non-destructive variant) when applicable → monthly budget snapshot card → disclaimer paragraph → Key Lesson card. Sections 2.2–2.6 define each.
+- Results live in `useState` (not persisted); inputs in `useLocalStorage` under key `'paycheck-calculator'`.
+
+**Step 3 — registration.** In `src/App.tsx`:
+1. Add to the static import block (after line 22, keeping the existing comment about why imports are static — do NOT convert anything to `React.lazy`):
+   ```ts
+   import { PaycheckCalculator } from '@/components/PaycheckCalculator'
+   ```
+2. Add `Wallet` to the existing `@phosphor-icons/react` import list (lines 4-15).
+3. Insert into the `calculators` array (line 42+) **as the second element**, directly after the `retirement` entry:
+   ```ts
+   { id: 'paycheck', labels: { short: 'Paycheck', full: 'Paycheck Estimator' }, icon: Wallet, component: PaycheckCalculator },
+   ```
+   No other `App.tsx` changes: the generic `TabsContent` mapping (lines 192-218) renders any registered calculator automatically.
+
+**Step 4 — verify** per §6. No changes to `vite.config.ts`, `index.html`, the PWA manifest, or routing are needed or permitted — the tab system is purely client-state and works under the `/FREEDomCalculator/` base as-is.
+
+---
+
+## 6. Acceptance criteria & verification
+
+There is no test runner (confirmed: no `test` script in `package.json`) — verification is typecheck + build + manual assertions.
+
+1. `npm run typecheck` passes (strict TS; **zero** `as any`, zero non-null `!` assertions in the new files).
+2. `npm run build` succeeds; bundle warning may appear (pre-existing, see docs/CODE-REVIEW.md PERF-1) but no **new** errors.
+3. `npm run dev` → Paycheck tab appears **second**, icon renders, tab switch works, no console errors.
+4. Enter each worked example A–D from §4.4 and confirm every asserted number (±$1 annual / ±$0.05 per-period).
+5. Example E behaviors: blank-input error, $10k FICA-only case, 401(k) cap warning, premium-exceeds-gross error.
+6. Persistence: set salary to $75,000, switch state to CA, reload the page → both values retained (localStorage key `paycheck-calculator`).
+7. Frequency sanity: with fixed inputs, weekly net × 52 ≈ biweekly net × 26 ≈ monthly net × 12 (within cents).
+8. Every `approx`-tier state shows its "simplified estimate" note; every `none`-tier state shows the $0 celebration row; disclaimer paragraph is visible without scrolling past the fold of the results.
+9. `npm run preview` after build: tab works under the `/FREEDomCalculator/` base path (no absolute-path asset references were added).
+10. Data integrity: `paycheck-tax-tables.ts` has 51 state entries, no remaining `TODO` markers, and the header's source URLs + access date are current.
+
+---
+
+## 7. Task breakdown for implementing agents
+
+Independently assignable; B and C depend on A's exported types compiling (A can stub rates with TODOs for B/C to start, but §6.10 gates final done).
+
+| Task | Scope | Inputs | Outputs | Done when |
+|---|---|---|---|---|
+| **A — Tax data + math library** | `src/lib/paycheck-tax-tables.ts` only | §3 in full; source URLs in §3.1; the `TODO(verify)` MFJ-37% check against [Rev. Proc. 2025-32](https://www.irs.gov/pub/irs-drop/rp-25-32.pdf) | The complete data file + 4 pure functions | Hand-evaluating the four functions reproduces every number in §4.4 A–D; §6.10 satisfied; `npm run typecheck` passes |
+| **B — Component UI + compute wiring** | `src/components/PaycheckCalculator.tsx` (no chart/lesson yet) | §2.2–2.4, §4.1–4.3; Task A's module | Working inputs, validation, results cards, persistence | Examples A–E verified in the browser; §6.6 persistence check passes |
+| **C — Chart, budget snapshot, hero, Key Lesson, disclaimers** | Same component file | §2.5–2.6 | Donut chart with aria-label, 50/30/20 card, hero banner, lesson card, disclaimer text | Visual parity with sibling calculators at mobile (375px) and desktop widths; §6.8 |
+| **D — Registration + full verification** | `src/App.tsx` (3-line change) + running §6 | §5 step 3; §6 checklist | Registered second tab; a filled-in §6 checklist pasted into the PR description | All 10 items in §6 pass; `npm run build` output committed to PR notes |
+
+**Ground rules for all tasks:** no new npm dependencies; no changes to any file not named in the task's Scope; preserve static imports in `App.tsx`; use `@/` imports; follow the `NumericOrEmpty`/validate-first/formatters conventions everywhere (they are demonstrated end-to-end in `src/components/CompoundInterestCalculator.tsx` — read it first).
+
+---
+
+## 8. Explicit non-goals (v1) — recorded so nobody "helpfully" adds them
+
+Overtime pay, bonuses/supplemental-wage withholding, MFS filing status, dependents/child tax credit, itemized deductions, HSA/FSA, Roth 401(k), after-tax deductions, local/city taxes, state standard deductions & credits, YTD/mid-year proration, W-4 allowance modeling, multi-job coordination. Each is a candidate for a future iteration only after a real request.


### PR DESCRIPTION
## What

Two documentation deliverables — **no application source changes** in this PR:

- **`docs/CODE-REVIEW.md`** — full security/performance/stability review of the app. 18 findings with file:line references, hand-off-ready fix instructions, and a prioritized backlog. Headliners:
  - The PWA registers a service worker (VitePWA) and then `main.tsx` purges it on every load — offline support is dead and every fresh session pays an extra reload (ST-1).
  - `useLocalStorage` trusts `JSON.parse` blindly and calculators dereference it with ~35 `data!` assertions (SEC-1/ST-2).
  - Compound Interest deposits always compound monthly regardless of the frequency selector (ST-4).
  - Single 890 kB JS chunk, fixable with `manualChunks` without touching the static-import constraint (PERF-1).
  - Plus solver-convergence, NaN/Infinity, iframe-hardening, dead-dependency, and doc-drift findings.

- **`docs/PAYCHECK-ESTIMATOR-SPEC.md`** — complete, buildable spec for a new "Paycheck Estimator" tab:
  - Verified **2026** tax data with citations (IRS Rev. Proc. 2025-32, Notice 2025-67, SSA wage base, Tax Foundation state rates), including a flagged source discrepancy to verify (MFJ 37% threshold).
  - Three-tier state model (9 no-tax / 15 flat / graduated-as-approximation), default TN.
  - Five hand-computed worked examples as acceptance assertions, a 10-point verification checklist, exact `App.tsx` registration steps, and an A–D subtask breakdown for implementing agents.

## Why

Requested review + spec pass (see `FABLE-PROMPT.md` in the repo root): a read-only audit of the existing app, and a spec detailed enough that a smaller model can implement the new calculator end-to-end without clarification.

## Notes for reviewers

- All bundle-size and `dist/index.html` claims in the review were verified against a fresh `npm run build`; `npm audit` reports 0 vulnerabilities.
- Working-tree source fixes matching the review findings exist locally but were deliberately **excluded** from this PR (docs only, per author direction).
- The spec's state-tax table has `TODO(data)` markers that are part of the spec's task breakdown (Task A), to be filled from the cited Tax Foundation source at implementation time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)