### PR TITLE
Rework Future You results header into a two-column layout

### DIFF
--- a/src/components/RetirementPlanner.tsx
+++ b/src/components/RetirementPlanner.tsx
@@ -324,9 +324,10 @@ export function RetirementPlanner() {
 
       {results && (
         <>
-          {/* Hero result */}
-          <Card className="overflow-hidden">
-            <CardContent className="pt-6">
+          {/* Hero result + stat trio */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-stretch">
+          <Card className="overflow-hidden h-full">
+            <CardContent className="pt-6 h-full flex items-center justify-center">
               <div className="flex flex-col items-center text-center gap-2">
                 <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-bold uppercase tracking-wide text-primary">
                   <Rocket size={14} weight="fill" /> Future You at {toNumber(data.retirementAge)}
@@ -354,7 +355,7 @@ export function RetirementPlanner() {
           </Card>
 
           {/* Stat trio */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 content-between">
             <Card>
               <CardContent className="pt-6 flex items-start gap-3">
                 <PiggyBank size={26} weight="duotone" className="text-muted-foreground shrink-0" />
@@ -385,6 +386,7 @@ export function RetirementPlanner() {
                 </div>
               </CardContent>
             </Card>
+          </div>
           </div>
 
           {/* Cost of waiting */}


### PR DESCRIPTION
## Why

On the Future You tab, the "Future You at X" hero card spanned the full width and left a lot of empty whitespace, while the three summary stat cards sat in a separate full-width row below it. The space wasn't being used effectively.

## What changed

Wrapped the hero card and the three stat cards in a single responsive two-column grid:

- The **hero card** now occupies the **left half** and fills the full row height so it stays the prominent focal point.
- The three stat cards (**You contribute**, **Compound growth**, **Retirement income**) now **stack vertically in the right half**, alongside the hero, so the previously empty space is put to use.
- On small screens the grid collapses back to a single stacked column, preserving the mobile experience.

## Notes

This is a layout-only change scoped to `src/components/RetirementPlanner.tsx`; no calculation logic was touched. `npm run build` succeeds. The one pre-existing recharts tooltip-formatter type error in this file is unrelated to this change and was present before it.